### PR TITLE
Fixed faulty equality comparison in TenantShellResolver

### DIFF
--- a/src/Dotnettency/TenantShell/TenantShellResolver.cs
+++ b/src/Dotnettency/TenantShell/TenantShellResolver.cs
@@ -60,9 +60,10 @@ namespace Dotnettency
                 bool distinguisherFound = false;
                 foreach (var item in tenantResult.Distinguishers)
                 {
-                    if (item == identifier)
+                    if (item.Equals(identifier))
                     {
                         distinguisherFound = true;
+                        continue;
                     }
                     _cache.AddOrUpdate(item, tenantResult, (a, b) => { return tenantResult; });
                 }


### PR DESCRIPTION
`item == identifier` would always evaluate to `false` because of reference comparison, leading to `distinguisherFound` always being `false`.

As a result, the `identifier` would always get added to `tenantResult.Distinguishers`, even when already part of `tenantResult.Distinguishers`.

Using `item.Equals(identifier)` works as intended, overloading the `==` operator of `TenantIdentifier` might be worth looking into to prevent regressions of the same sort.

Also, an unnecessary cache update was performed on line 67 (now 68) if `identifier` and `item` were identical.